### PR TITLE
proposal router

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -10,15 +10,16 @@ datasource db {
 }
 
 model Partnership {
-    id           String   @id @default(cuid())
-    title        String   @db.VarChar(200)
+    id           String     @id @default(cuid())
+    title        String     @db.VarChar(200)
     category     Category
     twitterURI   String
     websiteURI   String
-    description  String   @db.VarChar(2000)
+    description  String     @db.VarChar(2000)
     ownerAddress String
-    createdAt    DateTime @default(now())
+    createdAt    DateTime   @default(now())
     signature    String
+    proposals    Proposal[]
 }
 
 enum Category {
@@ -30,4 +31,19 @@ enum Category {
     COLLAB
     PARTNERSHIPS
     OTHER
+}
+
+model Proposal {
+    id            String       @id @default(cuid())
+    name          String       @db.VarChar(200)
+    comment       String       @db.VarChar(2000)
+    accepted      Boolean      @default(false)
+    createdAt     DateTime     @default(now())
+    occupation    String       @db.VarChar(200)
+    twitterURI    String
+    websiteURI    String
+    Partnership   Partnership? @relation(fields: [partnershipId], references: [id])
+    partnershipId String?
+
+    @@index([partnershipId])
 }

--- a/src/server/api/root.ts
+++ b/src/server/api/root.ts
@@ -1,5 +1,6 @@
 import { createTRPCRouter } from "~/server/api/trpc";
 import { partnershipRouter } from "~/server/api/routers/partnership/partnership.router";
+import { proposalRouter } from "~/server/api/routers/proposal/proposal.router";
 
 /**
  * This is the primary router for your server.
@@ -8,6 +9,7 @@ import { partnershipRouter } from "~/server/api/routers/partnership/partnership.
  */
 export const appRouter = createTRPCRouter({
   partnership: partnershipRouter,
+  proposal: proposalRouter,
 });
 
 // export type definition of API

--- a/src/server/api/routers/proposal/proposal.controller.ts
+++ b/src/server/api/routers/proposal/proposal.controller.ts
@@ -1,0 +1,73 @@
+import {
+  type UpdateProposalInput,
+  type CreateProposalInput,
+  type GetProposalsInput,
+  type DeleteProposalInput,
+} from "~/server/api/routers/proposal/proposal.schema";
+import {
+  createProposal,
+  deleteProposal,
+  findAllProposals,
+  updateProposal,
+} from "~/server/api/routers/proposal/proposal.service";
+
+export const getProposalsHandler = async (input: GetProposalsInput) => {
+  const partnershipId = input.partnershipId;
+  const cursor = input.cursor;
+  const limit = input.limit ?? 10;
+
+  const ptoposals = await findAllProposals({
+    take: limit + 1,
+    cursor: cursor ? { id: cursor } : undefined,
+    where: {
+      partnershipId,
+    },
+    orderBy: {
+      createdAt: "desc",
+    },
+  });
+
+  let nextCursor: typeof cursor | undefined = undefined;
+
+  if (ptoposals.length > limit) {
+    const nextProposal = ptoposals.pop();
+
+    nextCursor = nextProposal?.id;
+  }
+  return {
+    nextCursor,
+    ptoposals,
+  };
+};
+
+export const createProposalHandler = async (input: CreateProposalInput) =>
+  createProposal({
+    data: input,
+    select: {
+      id: true,
+      name: true,
+      comment: true,
+      accepted: true,
+      createdAt: true,
+      occupation: true,
+      twitterURI: true,
+    },
+  });
+
+export const uptateProposalHandler = ({ id, ...data }: UpdateProposalInput) =>
+  updateProposal({
+    where: { id },
+    data: { ...data },
+    select: {
+      id: true,
+      name: true,
+      comment: true,
+      accepted: true,
+      createdAt: true,
+      occupation: true,
+      twitterURI: true,
+    },
+  });
+
+export const deleteProposalHandler = ({ id }: DeleteProposalInput) =>
+  deleteProposal({ where: { id } });

--- a/src/server/api/routers/proposal/proposal.router.ts
+++ b/src/server/api/routers/proposal/proposal.router.ts
@@ -1,0 +1,28 @@
+import {
+  createProposalHandler,
+  deleteProposalHandler,
+  getProposalsHandler,
+  uptateProposalHandler,
+} from "~/server/api/routers/proposal/proposal.controller";
+import {
+  createProposalSchema,
+  deleteProposalSchema,
+  getProposalsSchema,
+  updateProposalSchema,
+} from "~/server/api/routers/proposal/proposal.schema";
+import { createTRPCRouter, publicProcedure } from "~/server/api/trpc";
+
+export const proposalRouter = createTRPCRouter({
+  getProposals: publicProcedure
+    .input(getProposalsSchema)
+    .query(({ input }) => getProposalsHandler(input)),
+  createProposal: publicProcedure
+    .input(createProposalSchema)
+    .query(({ input }) => createProposalHandler(input)),
+  updateProposal: publicProcedure
+    .input(updateProposalSchema)
+    .query(({ input }) => uptateProposalHandler(input)),
+  deleteProposal: publicProcedure
+    .input(deleteProposalSchema)
+    .query(({ input }) => deleteProposalHandler(input)),
+});

--- a/src/server/api/routers/proposal/proposal.schema.ts
+++ b/src/server/api/routers/proposal/proposal.schema.ts
@@ -1,0 +1,28 @@
+import { type TypeOf, number, object, string, boolean } from "zod";
+
+export const getProposalsSchema = object({
+  partnershipId: string().cuid(),
+  limit: number().min(1).max(100).nullish(),
+  cursor: string().cuid().nullish(),
+});
+
+export const createProposalSchema = object({
+  name: string().max(200),
+  comment: string().max(2000),
+  occupation: string().max(200),
+  twitterURI: string().url(),
+  websiteURI: string().url(),
+  partnershipId: string().cuid(),
+});
+
+export const updateProposalSchema = createProposalSchema
+  .omit({ partnershipId: true })
+  .merge(object({ id: string().cuid(), accepted: boolean() }))
+  .partial();
+
+export const deleteProposalSchema = object({ id: string().cuid() });
+
+export type GetProposalsInput = TypeOf<typeof getProposalsSchema>;
+export type CreateProposalInput = TypeOf<typeof createProposalSchema>;
+export type UpdateProposalInput = TypeOf<typeof updateProposalSchema>;
+export type DeleteProposalInput = TypeOf<typeof deleteProposalSchema>;

--- a/src/server/api/routers/proposal/proposal.service.ts
+++ b/src/server/api/routers/proposal/proposal.service.ts
@@ -1,0 +1,18 @@
+import { type Prisma } from "@prisma/client";
+import { prisma } from "~/server/db";
+
+export const findAllProposals = (
+  args: Pick<
+    Prisma.ProposalFindManyArgs,
+    "take" | "where" | "orderBy" | "cursor"
+  >
+) => prisma.proposal.findMany(args);
+
+export const createProposal = (args: Prisma.ProposalCreateArgs) =>
+  prisma.proposal.create(args);
+
+export const updateProposal = (args: Prisma.ProposalUpdateArgs) =>
+  prisma.proposal.update(args);
+
+export const deleteProposal = (args: Prisma.ProposalDeleteArgs) =>
+  prisma.proposal.delete(args);


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR adds a new `proposal` router to the server API and implements CRUD operations for proposals. It also adds a new Prisma model for proposals and updates the `Partnership` model to have a one-to-many relationship with proposals.

### Detailed summary
- Adds a new `proposal` router to the server API
- Implements CRUD operations for proposals
- Adds a new Prisma model for proposals
- Updates the `Partnership` model to have a one-to-many relationship with proposals

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->