### PR TITLE
fix-routes-mutations

### DIFF
--- a/src/server/api/routers/partnership/partnership.router.ts
+++ b/src/server/api/routers/partnership/partnership.router.ts
@@ -18,7 +18,7 @@ export const partnershipRouter = createTRPCRouter({
   getPartnerships: publicProcedure
     .input(getPartnershipsSchema)
     .query(({ input }) => getPartnershipsHandler(input)),
-  createPartnerShip: publicProcedure
+  createPartnership: publicProcedure
     .input(createPartnershipSchema)
-    .query(({ input }) => createPartnershipHandler(input)),
+    .mutation(({ input }) => createPartnershipHandler(input)),
 });

--- a/src/server/api/routers/proposal/proposal.router.ts
+++ b/src/server/api/routers/proposal/proposal.router.ts
@@ -18,11 +18,11 @@ export const proposalRouter = createTRPCRouter({
     .query(({ input }) => getProposalsHandler(input)),
   createProposal: publicProcedure
     .input(createProposalSchema)
-    .query(({ input }) => createProposalHandler(input)),
+    .mutation(({ input }) => createProposalHandler(input)),
   updateProposal: publicProcedure
     .input(updateProposalSchema)
-    .query(({ input }) => uptateProposalHandler(input)),
+    .mutation(({ input }) => uptateProposalHandler(input)),
   deleteProposal: publicProcedure
     .input(deleteProposalSchema)
-    .query(({ input }) => deleteProposalHandler(input)),
+    .mutation(({ input }) => deleteProposalHandler(input)),
 });


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the routers for the partnership and proposal APIs to use GraphQL mutations instead of queries for create, update, and delete operations.

### Detailed summary
- Renamed `createPartnerShip` to `createPartnership` in `partnership.router.ts`
- Changed `create`, `update`, and `delete` operations from queries to mutations in both `partnership.router.ts` and `proposal.router.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->