### PR TITLE
Created proposal modal

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "@hookform/resolvers": "^3.1.0",
     "@prisma/client": "^4.12.0",
+    "@radix-ui/react-dialog": "^1.0.3",
     "@radix-ui/react-label": "^2.0.1",
     "@radix-ui/react-select": "^1.2.1",
     "@radix-ui/react-separator": "^1.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,9 @@ dependencies:
   '@prisma/client':
     specifier: ^4.12.0
     version: 4.12.0(prisma@4.12.0)
+  '@radix-ui/react-dialog':
+    specifier: ^1.0.3
+    version: 1.0.3(@types/react@18.0.28)(react-dom@18.2.0)(react@18.2.0)
   '@radix-ui/react-label':
     specifier: ^2.0.1
     version: 2.0.1(react-dom@18.2.0)(react@18.2.0)
@@ -938,6 +941,33 @@ packages:
       react: 18.2.0
     dev: false
 
+  /@radix-ui/react-dialog@1.0.3(@types/react@18.0.28)(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-owNhq36kNPqC2/a+zJRioPg6HHnTn5B/sh/NjTY8r4W9g1L5VJlrzZIVcBr7R9Mg8iLjVmh6MGgMlfoVf/WO/A==}
+    peerDependencies:
+      react: ^16.8 || ^17.0 || ^18.0
+      react-dom: ^16.8 || ^17.0 || ^18.0
+    dependencies:
+      '@babel/runtime': 7.21.5
+      '@radix-ui/primitive': 1.0.0
+      '@radix-ui/react-compose-refs': 1.0.0(react@18.2.0)
+      '@radix-ui/react-context': 1.0.0(react@18.2.0)
+      '@radix-ui/react-dismissable-layer': 1.0.3(react-dom@18.2.0)(react@18.2.0)
+      '@radix-ui/react-focus-guards': 1.0.0(react@18.2.0)
+      '@radix-ui/react-focus-scope': 1.0.2(react-dom@18.2.0)(react@18.2.0)
+      '@radix-ui/react-id': 1.0.0(react@18.2.0)
+      '@radix-ui/react-portal': 1.0.2(react-dom@18.2.0)(react@18.2.0)
+      '@radix-ui/react-presence': 1.0.0(react-dom@18.2.0)(react@18.2.0)
+      '@radix-ui/react-primitive': 1.0.2(react-dom@18.2.0)(react@18.2.0)
+      '@radix-ui/react-slot': 1.0.1(react@18.2.0)
+      '@radix-ui/react-use-controllable-state': 1.0.0(react@18.2.0)
+      aria-hidden: 1.2.3
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+      react-remove-scroll: 2.5.5(@types/react@18.0.28)(react@18.2.0)
+    transitivePeerDependencies:
+      - '@types/react'
+    dev: false
+
   /@radix-ui/react-direction@1.0.0(react@18.2.0):
     resolution: {integrity: sha512-2HV05lGUgYcA6xgLQ4BKPDmtL+QbIZYH5fCOTAOOcJ5O0QbWS3i9lKaurLzliYUDhORI2Qr3pyjhJh44lKA3rQ==}
     peerDependencies:
@@ -1039,6 +1069,19 @@ packages:
     dependencies:
       '@babel/runtime': 7.21.5
       '@radix-ui/react-primitive': 1.0.2(react-dom@18.2.0)(react@18.2.0)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+    dev: false
+
+  /@radix-ui/react-presence@1.0.0(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-A+6XEvN01NfVWiKu38ybawfHsBjWum42MRPnEuqPsBZ4eV7e/7K321B5VgYMPv3Xx5An6o1/l9ZuDBgmcmWK3w==}
+    peerDependencies:
+      react: ^16.8 || ^17.0 || ^18.0
+      react-dom: ^16.8 || ^17.0 || ^18.0
+    dependencies:
+      '@babel/runtime': 7.21.5
+      '@radix-ui/react-compose-refs': 1.0.0(react@18.2.0)
+      '@radix-ui/react-use-layout-effect': 1.0.0(react@18.2.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
     dev: false

--- a/src/components/proposalModal.tsx
+++ b/src/components/proposalModal.tsx
@@ -1,0 +1,165 @@
+import { type SubmitHandler, useForm } from "react-hook-form";
+import TextField from "./textField";
+import { Button } from "./ui/button";
+import {
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from "./ui/dialog";
+import { yupResolver } from "@hookform/resolvers/yup";
+import * as yup from "yup";
+import { type FC, useId } from "react";
+import { api } from "~/utils/api";
+import { useAccount } from "wagmi";
+import { Proposal } from "@prisma/client";
+
+type Props = {
+  canEdit: boolean;
+  proposal: Proposal | null;
+  partnershipId: string;
+  closeModal: () => void;
+  onCreate: (proposal: Proposal) => void;
+};
+
+type ProposalFormInput = {
+  name: string;
+  twitterURI: string;
+  websiteURI: string;
+  comment: string;
+  occupation: string;
+};
+
+const formDataSchema = yup.object({
+  name: yup.string().max(200, "Too long").required("Required"),
+  comment: yup.string().max(200, "Too long").required("Required"),
+  occupation: yup.string().max(200, "Too long").required("Required"),
+  twitterURI: yup.string().url("Not a valid url").required("Required"),
+  websiteURI: yup.string().url("Not a valid url").required("Required"),
+});
+
+const ProposalModal: FC<Props> = ({
+  canEdit,
+  proposal,
+  partnershipId,
+  closeModal,
+  onCreate,
+}) => {
+  const formId = useId();
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+    reset,
+  } = useForm<ProposalFormInput>({
+    mode: "onBlur",
+    resolver: yupResolver(formDataSchema),
+    defaultValues: {
+      name: proposal?.name ?? "",
+      twitterURI: proposal?.twitterURI ?? "",
+      websiteURI: proposal?.websiteURI ?? "",
+      comment: proposal?.comment ?? "",
+      occupation: proposal?.occupation ?? "",
+    },
+  });
+  const { mutateAsync } = api.proposal.createProposal.useMutation();
+  const { address } = useAccount();
+
+  const onSubmit: SubmitHandler<ProposalFormInput> = async (formData) => {
+    try {
+      if (!address)
+        throw new Error("Only a connected account can create a partnership.");
+
+      const proposal = await mutateAsync({
+        ...formData,
+        partnerAddress: address,
+        partnershipId,
+      });
+      onCreate(proposal);
+      closeModal();
+      reset();
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  return (
+    <DialogContent>
+      <DialogHeader>
+        <DialogTitle>
+          {canEdit
+            ? "Create a Proposal"
+            : `Proposal from ${proposal?.name ?? ""}`}
+        </DialogTitle>
+        {canEdit && (
+          <DialogDescription>
+            Once the proposal is submitted the project owner will be notified
+            and will be able to accept or reject the proposal. Once accepted you
+            as the partner will be able to mint the partnership NFTs for both
+            parties.
+          </DialogDescription>
+        )}
+      </DialogHeader>
+      <div>
+        <form
+          id={formId}
+          className="grid grid-cols-1 gap-4 md:grid-cols-2"
+          // eslint-disable-next-line @typescript-eslint/no-misused-promises
+          onSubmit={handleSubmit(onSubmit)}
+        >
+          <TextField
+            label="Company name"
+            note="Max. 200 characters"
+            className="md:col-span-2"
+            {...register("name")}
+            error={errors.name?.message}
+            disabled={!canEdit}
+          />
+          <TextField
+            label="Comment"
+            note="Max. 200 characters"
+            {...register("comment")}
+            error={errors.comment?.message}
+            disabled={!canEdit}
+          />
+          <TextField
+            label="Occupation"
+            note="Max. 200 characters"
+            {...register("occupation")}
+            error={errors.occupation?.message}
+            disabled={!canEdit}
+          />
+          <TextField
+            label="Twitter URL"
+            {...register("twitterURI")}
+            error={errors.twitterURI?.message}
+            disabled={!canEdit}
+          />
+          <TextField
+            label="Website URL"
+            {...register("websiteURI")}
+            error={errors.websiteURI?.message}
+            disabled={!canEdit}
+          />
+        </form>
+      </div>
+      <DialogFooter>
+        <Button
+          type="button"
+          form={formId}
+          variant={canEdit ? "secondary" : "default"}
+          onClick={closeModal}
+        >
+          {canEdit ? "Cancel" : "Close"}
+        </Button>
+        {canEdit && (
+          <Button type="submit" form={formId}>
+            Confirm
+          </Button>
+        )}
+      </DialogFooter>
+    </DialogContent>
+  );
+};
+export default ProposalModal;

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -1,0 +1,128 @@
+"use client"
+
+import * as React from "react"
+import * as DialogPrimitive from "@radix-ui/react-dialog"
+import { X } from "lucide-react"
+
+import { cn } from "~/lib/utils"
+
+const Dialog = DialogPrimitive.Root
+
+const DialogTrigger = DialogPrimitive.Trigger
+
+const DialogPortal = ({
+  className,
+  children,
+  ...props
+}: DialogPrimitive.DialogPortalProps) => (
+  <DialogPrimitive.Portal className={cn(className)} {...props}>
+    <div className="fixed inset-0 z-50 flex items-start justify-center sm:items-center">
+      {children}
+    </div>
+  </DialogPrimitive.Portal>
+)
+DialogPortal.displayName = DialogPrimitive.Portal.displayName
+
+const DialogOverlay = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Overlay
+    ref={ref}
+    className={cn(
+      "fixed inset-0 z-50 bg-background/80 backdrop-blur-sm transition-all duration-100 data-[state=closed]:animate-out data-[state=closed]:fade-out data-[state=open]:fade-in",
+      className
+    )}
+    {...props}
+  />
+))
+DialogOverlay.displayName = DialogPrimitive.Overlay.displayName
+
+const DialogContent = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
+>(({ className, children, ...props }, ref) => (
+  <DialogPortal>
+    <DialogOverlay />
+    <DialogPrimitive.Content
+      ref={ref}
+      className={cn(
+        "fixed z-50 grid w-full gap-4 rounded-b-lg border bg-background p-6 shadow-lg animate-in data-[state=open]:fade-in-90 data-[state=open]:slide-in-from-bottom-10 sm:max-w-lg sm:rounded-lg sm:zoom-in-90 data-[state=open]:sm:slide-in-from-bottom-0",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
+        <X className="h-4 w-4" />
+        <span className="sr-only">Close</span>
+      </DialogPrimitive.Close>
+    </DialogPrimitive.Content>
+  </DialogPortal>
+))
+DialogContent.displayName = DialogPrimitive.Content.displayName
+
+const DialogHeader = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      "flex flex-col space-y-1.5 text-center sm:text-left",
+      className
+    )}
+    {...props}
+  />
+)
+DialogHeader.displayName = "DialogHeader"
+
+const DialogFooter = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      "flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2",
+      className
+    )}
+    {...props}
+  />
+)
+DialogFooter.displayName = "DialogFooter"
+
+const DialogTitle = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Title
+    ref={ref}
+    className={cn(
+      "text-lg font-semibold leading-none tracking-tight",
+      className
+    )}
+    {...props}
+  />
+))
+DialogTitle.displayName = DialogPrimitive.Title.displayName
+
+const DialogDescription = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Description
+    ref={ref}
+    className={cn("text-sm text-muted-foreground", className)}
+    {...props}
+  />
+))
+DialogDescription.displayName = DialogPrimitive.Description.displayName
+
+export {
+  Dialog,
+  DialogTrigger,
+  DialogContent,
+  DialogHeader,
+  DialogFooter,
+  DialogTitle,
+  DialogDescription,
+}

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -1,0 +1,13 @@
+import { Html, Head, Main, NextScript } from "next/document";
+
+export default function Document() {
+  return (
+    <Html className="dark">
+      <Head />
+      <body>
+        <Main />
+        <NextScript />
+      </body>
+    </Html>
+  );
+}


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR adds the `@radix-ui` library to the project and implements a proposal creation modal in the Partnerships page.

### Detailed summary
- Adds `@radix-ui` library and related dependencies to `package.json` and `pnpm-lock.yaml`.
- Implements a proposal creation modal in the Partnerships page using `@radix-ui/react-dialog`.
- Adds a `Proposal` type import to `partnerships/[id].tsx`.
- Adds a `ProposalModal` component to `components/proposalModal.tsx`.
- Implements form validation using `yup` and `react-hook-form` in `ProposalModal`.
- Implements proposal creation functionality using `api.proposal.createProposal.useMutation()` in `ProposalModal`.

> The following files were skipped due to too many changes: `src/components/proposalModal.tsx`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->